### PR TITLE
Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,5 @@ rando/Project/Content/Blueprints/Map/Encount/Mover/ParamTable/MapSymbolParamTabl
 debug/bossSpoilerLog.txt
 debug/encounterResults.txt
 debug/fusionResults.txt
+debug/currentSeed.txt
 rando.pak

--- a/Changes.txt
+++ b/Changes.txt
@@ -1,0 +1,15 @@
+Version 1.01
+Bugfixes:
+* Fixed quests being unable to complete if certain punishing foes are at their check
+* Fixed potential freeze at the Hydra check
+* Fixed level of Danu summons
+* Randomizer will no longer crash if one of normal bosses and punishing foes are randomized but not the other
+* Randomizer will no longer crash on computers with non-English settings
+* Old Lilith's Essence will no longer appear
+
+Balance:
+* Tutorial daemon now drops 5000 Macca, 2 Chakra Drops, and the Spyscope
+
+Misc:
+* Added more clarity if the randomizer crashes during generation
+* The randomizer now generates a file showing the seed

--- a/base/UniqueSkillAnimationMap.csv
+++ b/base/UniqueSkillAnimationMap.csv
@@ -169,3 +169,4 @@
 167,Lunation Flux,927,Bowl of Hygieia,149,
 168,Megido Ark,930,Catastrophe,192,
 169,Adversary,893,Counter,190,
+170,Root of Evil,875,Venom Chaser,202,

--- a/base_classes/demons.py
+++ b/base_classes/demons.py
@@ -18,6 +18,8 @@ class Compendium_Demon:
         self.learnedSkills = []
         self.alignment = None
         self.tendency = None
+        self.creationSpawn = Encounter_Spawn()
+        self.vengeanceSpawn = Encounter_Spawn()
     
 class Enemy_Demon:
     def __init__(self):
@@ -118,4 +120,8 @@ class Duplicate:
         self.enemyData = None
         self.sourceInd = None
         self.ind = None
-        
+
+class Encounter_Spawn:
+    def __init__(self):
+        self.mapNameID = None
+        self.zoneNameID = None

--- a/base_classes/encounters.py
+++ b/base_classes/encounters.py
@@ -35,6 +35,7 @@ class Event_Encounter:
         self.originalIndex = None
         self.positions = EventEncountPost()
         self.endEarlyFlag = None
+        self.startingPhase = None
         
     '''
     Tests if two encounters share identical demons, usually due to VR battles

--- a/boss_logic.py
+++ b/boss_logic.py
@@ -32,6 +32,7 @@ BOSS_SUMMONS = {
     925: [936], #Red Rider - Power
     926: [937], #Black Rider - Legion
     927: [938], #Pale Rider - Loa
+    843: [885], #Danu - Mandrake
 }
 
 #Boss IDs (first in the encounter) with multiple enemies of equal strength

--- a/randomizer.py
+++ b/randomizer.py
@@ -3668,12 +3668,8 @@ class Randomizer:
                 if encounter.ind in encountersWithBattleEvents:
                     eventInds = [jIndex for jIndex,e in enumerate(encountersWithBattleEvents) if e == encounter.ind] 
                     for ind in eventInds:
-                        # check if reference still has a event 
-                        if self.eventEncountArr[self.bossDuplicateMap[index]].ind in encountersWithBattleEvents:
-                            self.battleEventArr[ind].encounterID = self.eventEncountArr[self.bossDuplicateMap[index]].ind
-                        else:
-                            self.battleEventArr[ind].encounterID = 255
-                elif self.eventEncountArr[self.bossDuplicateMap[index]].ind in encountersWithBattleEvents:
+                        self.battleEventArr[ind].encounterID = 255
+                if self.eventEncountArr[self.bossDuplicateMap[index]].ind in encountersWithBattleEvents:
                 #reference has event but not duplicate 
                     eventInds = [jIndex for jIndex,e in enumerate(encountersWithBattleEvents) if e == self.eventEncountArr[self.bossDuplicateMap[index]].ind] 
                     for ind in eventInds:
@@ -5402,7 +5398,7 @@ class Randomizer:
         #Magatsuhi Tutorial Pretas
         self.battleEventArr[12].encounterID = 255
         #Guest Tutorial Glasya-Labolas
-        self.battleEventArr[35].enounterID = 255
+        self.battleEventArr[35].encounterID = 255
 
     '''
     Patches tutorial Daemon's HP to be beatable without Zio

--- a/randomizer.py
+++ b/randomizer.py
@@ -5698,6 +5698,8 @@ class Randomizer:
          if self.textSeed == "":
              self.textSeed = ''.join(random.choices(string.ascii_uppercase + string.digits, k=10))
              print('Your generated seed is: {}\n'.format(self.textSeed))
+             with open(paths.SEED_FILE, 'w', encoding="utf-8") as file:
+                file.write(self.textSeed)
          random.seed(self.textSeed)
          
     '''

--- a/randomizer.py
+++ b/randomizer.py
@@ -4087,11 +4087,11 @@ class Randomizer:
                 #Gather all essences of dmeons in the level range for the map
                 currentDemonNames = [demon.name + "'s Essence" for demon in self.compendiumArr if demon.level.value >= numbers.ESSENCE_MAP_SCALING[key][0] and demon.level.value <= numbers.ESSENCE_MAP_SCALING[key][1]]
                 for itemID, itemName in enumerate(self.itemNames): #Include all essences in the pool except Aogami/Tsukuyomi essences and demi-fiend essence
-                    if 'Essence' in itemName and 'Aogami' not in itemName and 'Tsukuyomi' not in itemName and 'Demi-fiend' not in itemName and itemID not in validEssences[key] and itemName in currentDemonNames:
+                    if 'Essence' in itemName and itemID not in numbers.BANNED_ESSENCES and itemID not in validEssences[key] and itemName in currentDemonNames:
                         validEssences[key].append(itemID)
         else:
             for itemID, itemName in enumerate(self.itemNames): #Include all essences in the pool except Aogami/Tsukuyomi essences and demi-fiend essence
-                if 'Essence' in itemName and 'Aogami' not in itemName and 'Tsukuyomi' not in itemName and 'Demi-fiend' not in itemName and itemID not in validEssences:
+                if 'Essence' in itemName and itemID not in numbers.BANNED_ESSENCES and itemID not in validEssences:
                     validEssences.append(itemID)
                 elif itemID < numbers.CONSUMABLE_ITEM_COUNT and itemID not in numbers.BANNED_ITEMS and 'NOT USED' not in itemName: #Include all consumable items
                     validItems.append(itemID)
@@ -4118,7 +4118,7 @@ class Randomizer:
                         emergencyEssences = []
                         currentDemonNames = [demon.name + "'s Essence" for demon in self.compendiumArr if demon.level.value >= numbers.ESSENCE_MAP_SCALING[chest.map][0] and demon.level.value <= numbers.ESSENCE_MAP_SCALING[chest.map][1]]
                         for itemID, itemName in enumerate(self.itemNames): #Include all essences in the pool except Aogami/Tsukuyomi essences and demi-fiend essence
-                            if 'Essence' in itemName and 'Aogami' not in itemName and 'Tsukuyomi' not in itemName and 'Demi-fiend' not in itemName and itemID not in emergencyEssences and itemName in currentDemonNames:
+                            if 'Essence' in itemName and itemID not in numbers.BANNED_ESSENCES and itemID not in emergencyEssences and itemName in currentDemonNames:
                                 emergencyEssences.append(itemID)
                         itemID = random.choice(emergencyEssences)
                     else:  
@@ -4209,11 +4209,11 @@ class Randomizer:
                 validEssences[area] = []
                 currentDemonNames = [demon.name + "'s Essence" for demon in self.compendiumArr if demon.level.value >= numbers.ESSENCE_MAP_SCALING[area][0] and demon.level.value <= numbers.ESSENCE_MAP_SCALING[area][1]]
                 for itemID, itemName in enumerate(self.itemNames): #Include all essences in the pool except Aogami/Tsukuyomi essences and demi-fiend essence
-                    if 'Essence' in itemName and 'Aogami' not in itemName and 'Tsukuyomi' not in itemName and 'Demi-fiend' not in itemName and itemID not in validEssences[area] and itemName in currentDemonNames:
+                    if 'Essence' in itemName and itemID not in numbers.BANNED_ESSENCES and itemID not in validEssences[area] and itemName in currentDemonNames:
                         validEssences[area].append(itemID)
         else:#no scaling items per area
             for itemID, itemName in enumerate(self.itemNames): #Include all essences in the pool except Aogami/Tsukuyomi essences and demi-fiend essence
-                if 'Essence' in itemName and 'Aogami' not in itemName and 'Tsukuyomi' not in itemName and 'Demi-fiend' not in itemName and itemID not in validEssences:
+                if 'Essence' in itemName and itemID not in numbers.BANNED_ESSENCES not in itemName and itemID not in validEssences:
                     validEssences.append(itemID)
                 elif itemID < numbers.CONSUMABLE_ITEM_COUNT and itemID not in numbers.BANNED_ITEMS and 'NOT USED' not in itemName: #Include all consumable items
                     validItems.append(itemID)
@@ -4280,11 +4280,11 @@ class Randomizer:
                 #Grab all essences in the predefined level range for the area
                 currentDemonNames = [demon.name + "'s Essence" for demon in self.compendiumArr if demon.level.value >= numbers.ESSENCE_MAP_SCALING[key][0] and demon.level.value <= numbers.ESSENCE_MAP_SCALING[key][1]]
                 for itemID, itemName in enumerate(self.itemNames): #Include all essences in the pool except Aogami/Tsukuyomi essences and demi-fiend essence
-                    if 'Essence' in itemName and 'Aogami' not in itemName and 'Tsukuyomi' not in itemName and 'Demi-fiend' not in itemName and itemID not in validEssences[key] and itemName in currentDemonNames:
+                    if 'Essence' in itemName and itemID not in numbers.BANNED_ESSENCES not in itemName and itemID not in validEssences[key] and itemName in currentDemonNames:
                         validEssences[key].append(itemID)
         else: #Rewards do not scale with map
             for itemID, itemName in enumerate(self.itemNames): #Include all essences in the pool except Aogami/Tsukuyomi essences and demi-fiend essence
-                if 'Essence' in itemName and 'Aogami' not in itemName and 'Tsukuyomi' not in itemName and 'Demi-fiend' not in itemName and itemID not in validEssences:
+                if 'Essence' in itemName and itemID not in numbers.BANNED_ESSENCES not in itemName and itemID not in validEssences:
                     validEssences.append(itemID)
                 elif itemID < numbers.CONSUMABLE_ITEM_COUNT and itemID not in numbers.BANNED_ITEMS and 'NOT USED' not in itemName: #Include all consumable items
                     validItems.append(itemID)

--- a/randomizer.py
+++ b/randomizer.py
@@ -6119,10 +6119,14 @@ if __name__ == '__main__':
         rando.fullRando(rando.configSettings)
         if not rando.configSettings.fixUniqueSkillAnimations:
             print('"Fix unique skill animations" patch not applied. If the game appears to hang during a battle animation, press the skip animations button')
+        print('\nRandomization complete! Place rando.pak in the Project/Content/Paks/~mods folder of your SMTVV game directory')
+        print('bossSpoilerLog, encounterResults and fusionResults can be found in the debug folder')
+        print('Lastly, it is recommended that you do not play the randomizer on hard mode Larpas')
        
     except RuntimeError:
         print('GUI closed - randomization was canceled')
-    print('\nRandomization complete! Place rando.pak in the Project/Content/Paks/~mods folder of your SMTVV game directory')
-    print('bossSpoilerLog, encounterResults and fusionResults can be found in the debug folder')
-    print('Lastly, it is recommended that you do not play the randomizer on hard mode Larpas')
+    except Exception as e:
+        print(e)
+        print('Unexpected error occured, randomization failed.\nPlease retry with different settings or send a screenshot of this error to the SMT Rando Discord\n https://discord.gg/d25ZAha')
+    
     input('Press [Enter] to exit')

--- a/randomizer.py
+++ b/randomizer.py
@@ -103,7 +103,7 @@ class Randomizer:
             The buffer containing CharacterNames
     '''
     def readDemonNames(self):
-        with open(paths.CHARACTER_NAME_IN, 'r', encoding="utf-8") as file:
+        with open(paths.CHARACTER_NAME_IN, 'r') as file:
             fileContents = file.read()   
             tempArray = fileContents.split("MessageLabel=")
             tempArray.pop(0)
@@ -3559,7 +3559,7 @@ class Randomizer:
         self.adjustBasicEnemyDrops(replacements, enemyArr)
         self.missionArr = self.adjustMissionsRequiringNormalDemons(replacements,enemyArr, self.missionArr)
 
-        with open(paths.ENCOUNTERS_DEBUG, 'w') as spoilerLog: #Create spoiler log
+        with open(paths.ENCOUNTERS_DEBUG, 'w', encoding="utf-8") as spoilerLog: #Create spoiler log
             for pair in replacements:
                 spoilerLog.write(self.enemyNames[pair[0]] + " replaced by " + self.enemyNames[pair[1]] + "\n")
         return newSymbolArr
@@ -3628,7 +3628,7 @@ class Randomizer:
         encounterPools = bossLogic.createBossEncounterPools(self.eventEncountArr, self.encountArr, self.uniqueSymbolArr, self.abscessArr, self.bossDuplicateMap, self.configSettings)
         if not encounterPools:
             return
-        with open(paths.BOSS_SPOILER, 'w') as spoilerLog: #Create spoiler log
+        with open(paths.BOSS_SPOILER, 'w', encoding="utf-8") as spoilerLog: #Create spoiler log
             for filteredEncounters in encounterPools:
                 shuffledEncounters = sorted(filteredEncounters, key=lambda x: random.random()) #First filter the encounters and shuffle the ones to randomize
                 shuffledEncounters = [copy.deepcopy(x) for x in shuffledEncounters] 
@@ -5439,6 +5439,10 @@ class Randomizer:
             
         questBossIDs = copy.deepcopy(numbers.QUEST_DROPS_BOSSES)
         
+        if questBossIDs == replacementDemonIDs:
+            #Everyone is the same
+            return
+
         #First set drops for quest bosses which aren't replaced by a quest boss or show up as replacement
         toRemove = []
         for index, demonID in enumerate(questBossIDs):
@@ -6041,7 +6045,7 @@ class Randomizer:
                         for demon in ec.encounter.demons:
                             finalString = finalString + demon + ' '
                         finalString = finalString + '\n'
-        with open(paths.ENCOUNTERS_DEBUG, 'w') as file:
+        with open(paths.ENCOUNTERS_DEBUG, 'w', encoding="utf-8") as file:
             file.write(finalString)
             
     def findEncounterBattle(self, id2, symbolEncs):
@@ -6060,7 +6064,7 @@ class Randomizer:
         finalString = ""
         for fusion in fusions:
             finalString = finalString + fusion.firstDemon.translation + " + " + fusion.secondDemon.translation + " = " + fusion.result.translation + '\n'
-        with open(paths.FUSION_DEBUG, 'w') as file:
+        with open(paths.FUSION_DEBUG, 'w', encoding="utf-8") as file:
             file.write(finalString)
                     
 if __name__ == '__main__':

--- a/randomizer.py
+++ b/randomizer.py
@@ -1088,7 +1088,8 @@ class Randomizer:
                 'levelpath': offset,
                 'unknownDemon': offset + 0x38,
                 '23Flag': offset + 0x23,
-                'battlefield': offset + 0x24
+                'battlefield': offset + 0x24,
+                'startingPhase': offset + 0x30,
             }
             encounter.unknown23Flag = data.readByte(offset + 0x23)
             encounter.battlefield = data.readByte(offset + 0x24)
@@ -1100,6 +1101,7 @@ class Randomizer:
                 demons.append(Translated_Value(data.readHalfword(offset + 0x48 + 2 * number),self.enemyNames[data.readHalfword(offset + 0x48 + 2 * number)]))
 
             encounter.demons = demons
+            encounter.startingPhase = data.readByte(offset + 0x30)
             encounter.originalIndex = index
             #Check if encounter is a duplicate and store that information in bossDuplicateMap if so
             originalIndex = next((x for x, val in enumerate(self.eventEncountArr) if val.compareDemons(encounter)), -1)
@@ -2561,6 +2563,7 @@ class Randomizer:
             buffer.write32chars(enc.levelpath, enc.offsets['levelpath'])
             buffer.writeHalfword(enc.unknownDemon.value, enc.offsets['unknownDemon'])
             buffer.writeByte(enc.endEarlyFlag,enc.offsets['levelpath'] + 0x3A)
+            buffer.writeByte(enc.startingPhase,enc.offsets['startingPhase'])
             for index, demon in enumerate(enc.demons):
                 buffer.writeHalfword(demon.value , enc.offsets['demons'] + 2 * index)
         

--- a/randomizer.py
+++ b/randomizer.py
@@ -75,6 +75,7 @@ class Randomizer:
         self.bossSymbolReplacementMap = {}
         self.validBossDemons = set()
         self.essenceBannedBosses = set()
+        self.updatedMissionConditionIDs = []
 
         self.nahobino = Nahobino()
         
@@ -3956,7 +3957,7 @@ class Randomizer:
         #get all missions that require a boss to be killed
         eventEncountMissions = []
         for mission in self.missionArr:
-                if any(mission.ind != 48 and (condition.type == 1 and condition.ind >= numbers.NORMAL_ENEMY_COUNT) for condition in mission.conditions):
+                if any(mission.ind != 48 and mission.ind not in self.updatedMissionConditionIDs and (condition.type == 1 and condition.ind >= numbers.NORMAL_ENEMY_COUNT) for condition in mission.conditions):
                     eventEncountMissions.append([mission,mission.conditions[0].ind])
         for index, encounter in enumerate(originalEncounters):
             if encounter.demons[0] == shuffledEncounters[index].demons[0]:
@@ -3990,6 +3991,7 @@ class Randomizer:
                     pair[0].conditions[0].type = 1
                     pair[0].conditions[0].ind = keyDemon
                     pair[0].conditions[0].amount = amounts
+                    self.updatedMissionConditionIDs.append(pair[0].ind)
 
             if encounter.ind in fourHolyBeastEncounters:
                 hBIndex = fourHolyBeastEncounters.index(encounter.ind)
@@ -4022,7 +4024,7 @@ class Randomizer:
         #get all missions that require a boss to be killed
         symbolMissions = []
         for mission in self.missionArr:
-                if any(mission.ind not in [48, 83] and (condition.type == 1 and condition.ind >= numbers.NORMAL_ENEMY_COUNT) for condition in mission.conditions):
+                if any(mission.ind not in [48, 83] and mission.ind not in self.updatedMissionConditionIDs and (condition.type == 1 and condition.ind >= numbers.NORMAL_ENEMY_COUNT) for condition in mission.conditions):
                     symbolMissions.append([mission,mission.conditions[0].ind])
         #for mission in symbolMissions:
             #print(mission[0].reward.ind)

--- a/randomizer.py
+++ b/randomizer.py
@@ -24,6 +24,7 @@ import string
 import pandas as pd
 import copy
 import shutil
+import traceback
 
 RACE_ARRAY = ["None", "Unused", "Herald", "Megami", "Avian", "Divine", "Yoma", "Vile", "Raptor", "Unused9", "Deity", "Wargod", "Avatar", "Holy", "Genma", "Element", "Mitama", "Fairy", "Beast", "Jirae", "Fiend", "Jaki", "Wilder", "Fury", "Lady", "Dragon", "Kishin", "Kunitsu", "Femme", "Brute", "Fallen", "Night", "Snake", "Tyrant", "Drake", "Haunt", "Foul", "Chaos", "Devil", "Meta", "Nahobino", "Proto-fiend", "Matter", "Panagia", "Enigma", "UMA", "Qadistu", "Human", "Primal", "Void"]
 DEV_CHEATS = False
@@ -5452,6 +5453,10 @@ class Randomizer:
     def patchTutorialDaemon(self):
         daemon = self.bossArr[numbers.TUTORIAL_DAEMON_ID]
         daemon.stats.HP = 27 #Should die to 3 basic attacks always
+        daemon.money = 5000 #Add starting funds for qol
+        spyscopeDrop = Item_Drop(79, 'Spyscope', 100, 0) #Drop spyscope and chakra drop x2
+        chakraDrop = Item_Drop(2, 'Chakra Drop', 100, 0)
+        daemon.drops = Item_Drops(spyscopeDrop, chakraDrop, chakraDrop)
     
     '''
     Sets the drops of bosses which are quest relevant to their replacements and in cases where a quest drop boss replaces a quest drop boss makes sure that the drops of all bosses are not lost in conversion.
@@ -6128,6 +6133,7 @@ if __name__ == '__main__':
     except RuntimeError:
         print('GUI closed - randomization was canceled')
     except Exception as e:
+        traceback.print_exc()
         print(e)
         print('Unexpected error occured, randomization failed.\nPlease retry with different settings or send a screenshot of this error to the SMT Rando Discord\n https://discord.gg/d25ZAha')
     

--- a/research/EventEncount Hex Notes.txt
+++ b/research/EventEncount Hex Notes.txt
@@ -8,7 +8,7 @@ Entry start first: 45, second: A5 size:0x60
 2A size1? some kind of flag	(always set??)
 2B size1? another flag		(nuwa has this)
 2E size1-2? Battle Theme
-30 size1? always 2??
+30 size1? 0 for idk(duplicate yakumo and zhens), 1 for ambush, 2 for player start, 3 for field advantage
 38 size2 Some kind of demon id no idea what the effect is though
 3A size1 Set for Lilith, Yuzuru, Satan (ends the battle early if they are defeated when value is 1)
 48 size2 1st demon in battle

--- a/util/numbers.py
+++ b/util/numbers.py
@@ -113,6 +113,8 @@ KEY_ITEM_CUTOFF = 611
 #Item indices that correspond to reusable items like the return pillar or gleam grenade
 BANNED_ITEMS = [70, 73, 74, 75, 76, 77, 78, 79, 80, 81]
 
+BANNED_ESSENCES = [359,555,545,546,547,548,549,550,551,552,553,554,556,557,558,559,606,607,608] #Old Lilith's Essence, Demi-fiends Essence, Aogami & Tsukuyomi Essences
+
 #Chance that a miman reward is an essence
 MIMAN_ESSENCE_ODDS = 0.27272727
 #Odds of how many different items a miman reward has
@@ -181,7 +183,9 @@ VENGEANCE_EXCLUSIVE_KEY_REWARDS =[] #Currently not any
 #Exclusive mission from both canons to give potential exclusive rewards to (excluding missions whose rewards are not randomized or are not allowed to receive key item rewards)
 CREATION_EXLUSIVE_MISSIONS = [72,40,42,26,25,30,22,24,27,204,206,187,93] #The Falcon's Head, Egyptians Fate, Succesion of Ra, Path to Myojin Forest, One Mokois Trash,
         #He of a Hundred Hands, Hellfire Highway, Search for Oyamatsumi, Glitter in Ginza, Netherworld Relay Racing, Will of the Samurai, Trial of the Seven Stars, Defeat the Demon Kings Armies
-VENGEANCE_EXLUSIVE_MISSIONS = [] #TODO: Fill out (at least when there is a vengeance unique key reward)
+VENGEANCE_EXLUSIVE_MISSIONS = [157,152,159,177,171,194,203,178,202,184,200,210,172,211,193,174,188,190,108,109,110,111,112,113] #Supply Run, Guide to the Lost, Heart of Garnet, As God Wills, A Self of my Own, Devotion To Order, Part-time Gasser, A Star is Born
+        #Disgraced Bird God, Alice's Wonderland, Shinjuku Jewel Hunt, Heroes of Heaven and Earth, Rite of Resurrection, 'God of Old, Devourer of Kin', The Heartbroken, Special Training: Army of Chaos
+        #The Serpent King, The Great Adversary, Investigate the Anomalies in Tokyo, Investigate the Salt Incidents, Rescue Miyazu Atsuta, Investigate Jozoji Temple, Qadištu Showdown
 
 #Mutually exclusive missions that should never reward a key item
 MUTUALLY_EXCLUSIVE_MISSIONS = [

--- a/util/paths.py
+++ b/util/paths.py
@@ -85,6 +85,7 @@ ENCOUNT_MOVER_FOLDER_OUT = 'rando/Project/Content/Blueprints/Map/Encount/Mover'
 MOVER_PARAMTABLE_FOLDER_OUT = 'rando/Project/Content/Blueprints/Map/Encount/Mover/ParamTable'
 
 DEBUG_FOLDER = 'debug'
+SEED_FILE = 'debug/currentSeed.txt'
 ENCOUNTERS_DEBUG = 'debug/encounterResults.txt'
 FUSION_DEBUG = 'debug/fusionResults.txt'
 BOSSES_DEBUG = 'research/bossEncounters.csv'


### PR DESCRIPTION
Version 1.01 Hotfix primarily to stop softlocks/freezes in game and reduce errors in generation

Bugfixes:
* Fixed quests being unable to complete if certain punishing foes are at their check
* Fixed potential freeze at the Hydra check
* Fixed level of Danu summons
* Randomizer will no longer crash if one of normal bosses and punishing foes are randomized but not the other
* Randomizer will no longer crash on computers with non-English settings
* Old Lilith's Essence will no longer appear

Balance:
* Tutorial daemon now drops 5000 Macca, 2 Chakra Drops, and the Spyscope

Misc:
* Added more clarity if the randomizer crashes during generation
* The randomizer now generates a file showing the seed